### PR TITLE
fix: error reading JToken from JsonReader

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ def get_changelog_lines():
 def main():
     notes = get_changelog_lines()
     notes_dict = json.dumps({"notes": notes})
-    print(f"notes={notes_dict} >> $GITHUB_OUTPUT")
+    print(f"notes='{notes_dict}' >> $GITHUB_OUTPUT")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently the generated output is something like:
```
notes={"notes": some_array_value_here} >> $GITHUB_OUTPUT
```

I believe it should be
```
notes='{"notes": some_array_value_here}' >> $GITHUB_OUTPUT
```